### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/pacupd.fish
+++ b/functions/pacupd.fish
@@ -1,4 +1,4 @@
-which abs ^ /dev/null > /dev/null
+which abs 2> /dev/null > /dev/null
 if test $status -ne 1
   function pacupd -d "Update and refresh the local package and ABS databases against repositories"
     sudo pacman -Sy; and sudo abs


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618