### PR TITLE
Add yay AUR helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-
 # The Arch Linux Plugins
 
 The Arch Linux Plugins provides a number of plugins to make using arch easier.
+
+For documentation about this plugin read this [README.md](functions/README.md)

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,50 +1,50 @@
 
 # pacman functions #
 
-* pacin
+* `pacin`
 Install specific package(s) from the repositories
 
-* pacins
+* `pacins`
 Install specific package not from the repositories but from a file
 
-* pacre
+* `pacre`
 Remove the specified package(s), retaining its configuration(s) and required dependencies
 
-* pacrem
+* `pacrem`
 Remove the specified package(s), its configuration(s) and unneeded dependencies
 
-* pacrep
+* `pacrep`
 Display information about a given package in the repositories
 
-* pacreps
+* `pacreps`
 Search for package(s) in the repositories
 
-* pacloc
+* `pacloc`
 Display information about a given package in the local database
 
-* paclocs
+* `paclocs`
 Search for package(s) in the local database
 
-* pacupd
+* `pacupd`
 Update and refresh the local package and ABS databases against repositories
 
-* pacinsd
+* `pacinsd`
 Install given package(s) as dependencies of another package
 
-* pacmir
+* `pacmir`
 Force refresh of all package lists after updating /etc/pacman.d/mirrorlist
 
-* paclist
+* `paclist`
 List all installed packages with a short description - Source
 
-* paclsorphans
+* `paclsorphans`
 List all orphaned packages
 
-* pacrmorphans
+* `pacrmorphans`
 Delete all orphaned packages
 
-* pacdisowned | less +F
-List all disowned files in your system
+* `pacdisowned`
+List all disowned files in your system. For a prettier output run `pacdisowned | less +F`
 
 
 # Based on aliases from oh-my-zsh

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,5 +1,6 @@
+# Available funtions
 
-# pacman functions #
+## pacman functions
 
 * `pacin`
 Install specific package(s) from the repositories
@@ -28,6 +29,9 @@ Search for package(s) in the local database
 * `pacupd`
 Update and refresh the local package and ABS databases against repositories
 
+* `pacupg`
+Synchronize with repositories before upgrading packages that are out of date on the local system
+
 * `pacinsd`
 Install given package(s) as dependencies of another package
 
@@ -46,7 +50,12 @@ Delete all orphaned packages
 * `pacdisowned`
 List all disowned files in your system. For a prettier output run `pacdisowned | less +F`
 
+## yay functions
 
-# Based on aliases from oh-my-zsh
+All the yay functions are the same as the ones as the pacman functions but replacing `pac` with `ya`, e.g. `yain` is
+the same function as `pacin` but will search also in the AUR. `paclist`, `paclsorphans`, `pacrmorphans` and
+`pacdisowned` are not implemented since it doesn't make a lot of sense to use yay for those.
+
+## Based on aliases from oh-my-zsh
 
 Source: https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/archlinux/archlinux.plugin.zsh

--- a/functions/yay.fish
+++ b/functions/yay.fish
@@ -1,0 +1,51 @@
+# Defining all the funtions in the same file so the if stament is run only once
+
+# Test if yay is installed
+which yay 2> /dev/null > /dev/null
+if test $status -ne 1
+
+    function yain -d "Install specific package(s) from the repositories or the AUR"
+        yay -S $argv
+    end
+
+    function yains -d "Install specific package from a file"
+        yay -U $argv
+    end
+
+    function yare -d "Remove the specified package(s), retaining its configuration(s) and required dependencies"
+        yay -R $argv
+    end
+
+    function yarem -d "Remove the specified package(s), its configuration(s) and unneeded dependencies"
+        yay -Rns $argv
+    end
+
+    function yarep -d "Display information about a given package in the repositories or the AUR"
+        yay -Si $argv
+    end
+
+    function yareps -d "Search for package(s) in the repositories and the AUR"
+        yay -Ss $argv
+    end
+
+    function yacloc -d "Display information about a given package in the local database"
+        yay -Qi $argv
+    end
+
+    function yaupd -d "Update and refresh the local package database against repositories"
+        yay -Sy
+    end
+
+    function yaupg -d "Synchronize with repositories and upgrade all packages that are out of date on the local system from the repositories or the AUR."
+        yay -Syu $argv
+    end
+
+    function yainsd -d "Install given package(s) as dependencies of another package"
+        yay -Syu $argv
+    end
+
+    function yamir -d "Force refresh of all package lists after updating /etc/pacman.d/mirrorlist"
+        yay -Syy $argv
+    end
+
+end

--- a/functions/yay.fish
+++ b/functions/yay.fish
@@ -28,7 +28,7 @@ if test $status -ne 1
         yay -Ss $argv
     end
 
-    function yacloc -d "Display information about a given package in the local database"
+    function yaloc -d "Display information about a given package in the local database"
         yay -Qi $argv
     end
 


### PR DESCRIPTION
A new file `functions/yay.fish` is created, which contains the functions for the yay AUR helper. Only one file is preferred instead of the typical one file per function for performance reasons. Since fish needs to check if yay is installed before loading the functions, one file is used so the if statement is only evaluated once. Multiple files will ake the process much slower for loading the shell. The `functions/README.md` file is also updated to document these new functions. Only a short description is provided since the added functions are pretty much self-explanatory.
